### PR TITLE
Add Prisma user model and authentication endpoints

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+type LoginPayload = {
+  username: string;
+  password: string;
+};
+
+const sanitizeUser = (user: { password: string } & Record<string, unknown>) => {
+  const { password, ...rest } = user;
+  return rest;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as Partial<LoginPayload>;
+
+    if (!body.username || !body.password) {
+      return NextResponse.json({ message: 'username and password are required' }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { username: body.username },
+    });
+
+    if (!user || user.password !== body.password) {
+      return NextResponse.json({ message: 'Invalid credentials' }, { status: 401 });
+    }
+
+    if (!user.isActive) {
+      return NextResponse.json({ message: 'User is not active' }, { status: 403 });
+    }
+
+    return NextResponse.json({ user: sanitizeUser(user), message: 'Login successful' });
+  } catch (error) {
+    console.error('Error during login', error);
+    return NextResponse.json({ message: 'Error during login' }, { status: 500 });
+  }
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+type Params = {
+  params: {
+    id: string;
+  };
+};
+
+const sanitizeUser = (user: { password: string } & Record<string, unknown>) => {
+  const { password, ...rest } = user;
+  return rest;
+};
+
+export async function GET(_request: Request, { params }: Params) {
+  try {
+    const id = Number(params.id);
+
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ message: 'Invalid user id' }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id } });
+
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(sanitizeUser(user));
+  } catch (error) {
+    console.error('Error fetching user', error);
+    return NextResponse.json({ message: 'Error fetching user' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+  try {
+    const id = Number(params.id);
+
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ message: 'Invalid user id' }, { status: 400 });
+    }
+
+    const body = (await request.json()) as Record<string, unknown>;
+
+    const data: Record<string, unknown> = {};
+
+    if (typeof body.email === 'string') data.email = body.email;
+    if (typeof body.password === 'string') data.password = body.password;
+    if (typeof body.username === 'string') data.username = body.username;
+    if (typeof body.isActive === 'boolean') data.isActive = body.isActive;
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json({ message: 'No valid fields provided for update' }, { status: 400 });
+    }
+
+    const user = await prisma.user.update({
+      where: { id },
+      data,
+    });
+
+    return NextResponse.json(sanitizeUser(user));
+  } catch (error) {
+    console.error('Error updating user', error);
+    return NextResponse.json({ message: 'Error updating user' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  try {
+    const id = Number(params.id);
+
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ message: 'Invalid user id' }, { status: 400 });
+    }
+
+    await prisma.user.delete({ where: { id } });
+
+    return NextResponse.json({ message: 'User deleted' });
+  } catch (error) {
+    console.error('Error deleting user', error);
+    return NextResponse.json({ message: 'Error deleting user' }, { status: 500 });
+  }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+type UserPayload = {
+  email: string;
+  password: string;
+  username: string;
+  isActive?: boolean;
+};
+
+const sanitizeUser = (user: { password: string } & Record<string, unknown>) => {
+  const { password, ...rest } = user;
+  return rest;
+};
+
+export async function GET() {
+  try {
+    const users = await prisma.user.findMany();
+    return NextResponse.json(users.map(sanitizeUser));
+  } catch (error) {
+    console.error('Error fetching users', error);
+    return NextResponse.json({ message: 'Error fetching users' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as Partial<UserPayload>;
+
+    if (!body.email || !body.password || !body.username) {
+      return NextResponse.json({ message: 'email, password and username are required' }, { status: 400 });
+    }
+
+    const user = await prisma.user.create({
+      data: {
+        email: body.email,
+        password: body.password,
+        username: body.username,
+        isActive: body.isActive ?? true,
+      },
+    });
+
+    return NextResponse.json(sanitizeUser(user), { status: 201 });
+  } catch (error) {
+    console.error('Error creating user', error);
+    return NextResponse.json({ message: 'Error creating user' }, { status: 500 });
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = global.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.prisma = prisma;
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "next": "15.5.4",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.4"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
+    "prisma": "^5.22.0",
     "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id         Int      @id @default(autoincrement())
+  email      String   @unique @map("correo") @db.VarChar(191)
+  password   String   @db.VarChar(255)
+  isActive   Boolean  @default(true) @map("activo")
+  username   String   @unique @map("nombre_usuario") @db.VarChar(191)
+  createdAt  DateTime @default(now()) @map("fecha_creacion")
+}


### PR DESCRIPTION
## Summary
- add a Prisma schema targeting MySQL with a user table that stores email, password, activation flag, username, and creation timestamp
- configure a reusable Prisma client helper and project dependencies
- implement Next.js API route handlers for user CRUD operations and a login endpoint that validates active accounts and credentials

## Testing
- npm install *(fails: 403 Forbidden when downloading @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbc0649f8832f8041fe2ea0eb4bde